### PR TITLE
This PR fix the issue-1239

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "data-build": "node tools/data-builder.js",
     "data-rebuild": "node tools/data-rebuilder.js",
     "postinstall": "npm run data-build && npm run build:production && npm run build:server",
-    "template-build": "node tools/template-builder && npm run data-build",
+    "template-build": "node tools/template-builder",
+    "posttemplate-build": "npm run data-build",
     "test": "jest"
   },
   "author": "Marcin Treder",

--- a/tools/template-builder.js
+++ b/tools/template-builder.js
@@ -9,8 +9,7 @@ const systemsList = getSystemsDataFromSourceFiles();
 const fileTemplate = getTemplateStructure(systemsList);
 
 // Get companyName from cli argument
-const argName = JSON.parse(process.env.npm_config_argv, null, 2).remain[0];
-const companyName = argName !== undefined ? argName : 'new-system';
+const companyName = process.argv[2];
 
 // Prepare template
 fileTemplate.company.data = companyName;


### PR DESCRIPTION
close https://github.com/UXPin/uxpin-issues/issues/1239

The `npm run template-build` cmd is broken.
Root cause is npm removed `npm_config_*` env var since V6 (https://github.com/npm/rfcs/blob/main/implemented/0021-reduce-lifecycle-script-environment.md)